### PR TITLE
cd 

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -136,6 +136,11 @@ void execute(char * argv[]){
 	char *cmd = argv[0];
 	int pid, i, status;
 	
+	if(strcmp(cmd,"cd")==0 || strcmp(cmd,"chdir")==0) {
+		chdir(argv[1]);
+		return;
+	}
+
 	//Now two threads execute simultaneously (from next line itself)
 	pid = fork();
 	assert(pid>=0);


### PR DESCRIPTION
Fixes Issue #7 

It is not very robust. We do not accept commands like `cd < out ..`. I do not know what a command like that is supposed to do, but it seems to be supported in a normal shell. For us, I am assuming we have a command like `cd PATH` or `chdir PATH` with neither variations nor any other other arguments